### PR TITLE
Some little changes to get the package

### DIFF
--- a/pyk2/src/compile_f2py.sh
+++ b/pyk2/src/compile_f2py.sh
@@ -22,8 +22,6 @@ gfortran -fpic -c \
  string_tools.f90  \
  mod_units.f90  \
  bouncy_castle.f90  \
- libcrlibm.a  \
- libroundctl.a  \
  coll_jawfit.f90  \
  coll_common.f90  \
  coll_db.f90  \
@@ -31,7 +29,7 @@ gfortran -fpic -c \
  mod_funlux.f90  \
  coll_crystal.f90  \
  coll_k2.f90 \
- files.f90  \
+ files.f90 
 
 # link fortran
 f2py -m pyk2f -c pyk2.f90 \
@@ -53,5 +51,7 @@ f2py -m pyk2f -c pyk2.f90 \
  coll_crystal.o  \
  coll_k2.o \
  files.o  \
+ libcrlibm.a  \
+ libroundctl.a  
 
  mv pyk2f.*.so ../

--- a/pyk2/src/crlibm/CMakeLists.txt
+++ b/pyk2/src/crlibm/CMakeLists.txt
@@ -6,48 +6,11 @@ SET(CRLIBM2_SOURCES addition_scs.c double2scs.c multiplication_scs.c division_sc
 add_library(crlibm1 OBJECT ${CRLIBM1_SOURCES})
 add_library(crlibm2 OBJECT ${CRLIBM2_SOURCES})
 
-SET(CRLIBM_DEFS "-DLINUX_INLINE -DHAVE_CONFIG_H -I.")
-SET(CRLIBM_DEFS_DEBUG "-DHAVE_CONFIG_H -I.")
+set(lessWarnings  -Wno-sign-conversion -Wno-conversion -Wno-long-long)
 
-if(CMAKE_BUILD_TYPE STREQUAL Debug)
-	target_compile_definitions(crlibm1 PRIVATE ${CRLIBM_DEFS_DEBUG})
-	target_compile_definitions(crlibm2 PRIVATE ${CRLIBM_DEFS_DEBUG})
-else()
-	target_compile_definitions(crlibm1 PRIVATE ${CRLIBM_DEFS})
-	target_compile_definitions(crlibm2 PRIVATE ${CRLIBM_DEFS})
-endif()
-
-if(${CMAKE_SYSTEM_PROCESSOR} MATCHES AMD64 OR ${CMAKE_SYSTEM_PROCESSOR} MATCHES x86_64 OR ${CMAKE_SYSTEM_PROCESSOR} MATCHES i686)
-	if(32BIT)
-	  target_compile_options(crlibm1 PRIVATE -m32 -fPIC)
-	  target_compile_options(crlibm2 PRIVATE -m32 -fPIC)
-	endif(32BIT)
-	if(64BIT)
-	  target_compile_options(crlibm1 PRIVATE -m64 -fPIC)
-	  target_compile_options(crlibm2 PRIVATE -m64 -fPIC)
-	endif(64BIT)
-endif()
-
-if(${CMAKE_C_COMPILER_ID} MATCHES "GNU")
-	# In old crlibm, suppress some warnings. It's too many of them to be usefull...
-	set(lessWarnings  -Wno-sign-conversion -Wno-conversion -Wno-long-long)
-
-	if(${CMAKE_SYSTEM_PROCESSOR} MATCHES AMD64 OR ${CMAKE_SYSTEM_PROCESSOR} MATCHES x86_64 OR ${CMAKE_SYSTEM_PROCESSOR} MATCHES i686)  
-		target_compile_options(crlibm1 PRIVATE -mfpmath=sse -msse2 -fPIC -std=c99 -Wall -Wshadow -Wpointer-arith -Wcast-align -Wconversion -Waggregate-return -Wstrict-prototypes -Wnested-externs -Wlong-long -Winline -pedantic -fno-strict-aliasing ${lessWarnings})
-		target_compile_options(crlibm2 PRIVATE -mfpmath=sse -msse2 -Wall -Wshadow -Wpointer-arith -Wcast-align -Wconversion -Waggregate-return -Wstrict-prototypes -Wnested-externs -Wlong-long -Winline ${lessWarnings})
-	else()
-		target_compile_options(crlibm1 PRIVATE -fPIC -std=c99 -Wall -Wshadow -Wpointer-arith -Wcast-align -Wconversion -Waggregate-return -Wstrict-prototypes -Wnested-externs -Wlong-long -Winline -pedantic -fno-strict-aliasing ${lessWarnings})
-		target_compile_options(crlibm2 PRIVATE -Wall -Wshadow -Wpointer-arith -Wcast-align -Wconversion -Waggregate-return -Wstrict-prototypes -Wnested-externs -Wlong-long -Winline ${lessWarnings})
-	endif()
-  
-elseif(${CMAKE_C_COMPILER_ID} MATCHES "Intel")
-	target_compile_options(crlibm1 PRIVATE -msse2 -fPIC -std=c99 -Wall -Wshadow -Wpointer-arith -Wconversion -Wstrict-prototypes -Winline -pedantic -fno-strict-aliasing)
-	target_compile_options(crlibm2 PRIVATE -msse2 -Wall -Wshadow -Wpointer-arith -Wconversion -Wstrict-prototypes -Winline)
-else()
-	target_compile_options(crlibm1 PRIVATE -mfpmath=sse -msse2 -fPIC -std=c99 -Wall -Wshadow -Wpointer-arith -Wcast-align -Wconversion -Waggregate-return -Wstrict-prototypes -Wnested-externs -Wlong-long -Winline -pedantic -fno-strict-aliasing)
-	target_compile_options(crlibm2 PRIVATE -mfpmath=sse -msse2 -Wall -Wshadow -Wpointer-arith -Wcast-align -Wconversion -Waggregate-return -Wstrict-prototypes -Wnested-externs -Wlong-long -Winline)
-endif()
+target_compile_options(crlibm1 PRIVATE -mfpmath=sse -msse2 -fPIC -std=c99 -Wall -Wshadow -Wpointer-arith -Wcast-align -Wconversion -Waggregate-return -Wstrict-prototypes -Wnested-externs -Wlong-long -Winline -pedantic -fno-strict-aliasing ${lessWarnings})
+target_compile_options(crlibm2 PRIVATE -mfpmath=sse -msse2 -Wall -Wshadow -Wpointer-arith -Wcast-align -Wconversion -Waggregate-return -Wstrict-prototypes -Wnested-externs -Wlong-long -Winline ${lessWarnings})
 
 #glue the parts together
-add_library(crlibm STATIC $<TARGET_OBJECTS:crlibm1> $<TARGET_OBJECTS:crlibm2>)
+add_library(crlibm $<TARGET_OBJECTS:crlibm1> $<TARGET_OBJECTS:crlibm2>)
 

--- a/pyk2/src/executable_compile.sh
+++ b/pyk2/src/executable_compile.sh
@@ -2,5 +2,5 @@
 rm *.mod *.o
 
 gfortran \
-core_tools.f90 constants.f90 strings.f90 mod_alloc.f90 common_modules.f90 string_tools.f90 mod_units.f90 bouncy_castle.f90 libcrlibm.a libroundctl.a coll_jawfit.f90 coll_common.f90 coll_db.f90 mod_ranlux.f90 mod_funlux.f90 coll_crystal.f90 coll_k2.f90 \
-files.f90 main.f90 -g -O0 -o main
+core_tools.f90 constants.f90 strings.f90 mod_alloc.f90 common_modules.f90 string_tools.f90 mod_units.f90 bouncy_castle.f90  coll_jawfit.f90 coll_common.f90 coll_db.f90 mod_ranlux.f90 mod_funlux.f90 coll_crystal.f90 coll_k2.f90 \
+files.f90 main.f90 libcrlibm.a libroundctl.a -g -O0 -o main


### PR DESCRIPTION
to a working state!

Baiscally I did the following:

* Remove everything "redundant" from the faulty `pyk2/src/crlibm/CMakeLists.txt` file so that I could get exactly one line of settings to execute. This alone lead to a working linking phase of the two object libraries.
* Fix some elements in the `pyk2/src/compile_f2py.sh`, as there was some elements that did not seem right to me (the `gfortran` command is supposed to compile separately all the frotran codes and make them into object files, than the `f2py` tool needs the main sourcefile, all the fortran object files, and finally the C object files).

Theoretically, the cmake file needs to be remade so that it can support different compilers (but I have no strong experience in this yet...)